### PR TITLE
perf: benchmark scanner/writer pipeline and cut Flush allocation

### DIFF
--- a/BENCHMARK_REPORT.md
+++ b/BENCHMARK_REPORT.md
@@ -10,6 +10,37 @@
 
 Carve v0.4.0 introduces a new **high-performance Scanner API** that achieves **55x faster parsing** and **zero allocations** compared to the regex-based approach. The benchmarks demonstrate that the new Scanner API is production-ready for high-throughput log processing workloads.
 
+## v0.4.3 Throughput Experiment Log (March 29, 2026)
+
+Reproducible command:
+
+```bash
+go test ./pkg/carve -run '^$' -bench '^(BenchmarkScannerScan|BenchmarkWriterWriteLinesSIMD|BenchmarkFlush|BenchmarkEndToEndPipeline)$' -benchmem -benchtime=3s -count=3
+```
+
+### Change 1 (REVERTED): manual delimiter scan in `Scanner.Scan`
+
+Hypothesis: replacing `bytes.IndexByte` with an inline delimiter loop removes subslice overhead and improves branch predictability.
+
+Result: rejected. `ScannerScan` regressed substantially (about 140ns/op ➜ 230ns/op in the short-run experiment), so `bytes.IndexByte` was restored.
+
+Conclusion: **REVERT**.
+
+### Change 2 (KEPT): reuse `[]arrow.Array` scratch in `Writer.Flush`
+
+Hypothesis: reusing the `arrs` slice in `Flush` removes one allocation per flush and reduces GC pressure in hot write/flush loops.
+
+| Change | ns/op | B/op | allocs/op | throughput |
+| ------ | ----- | ---- | --------- | ---------- |
+| Baseline `BenchmarkWriterWriteLinesSIMD` | 1,675,974 | 1,271,850 | 63 | 254.54 MB/s |
+| Reuse `arrs` slice (`BenchmarkWriterWriteLinesSIMD`) | 1,614,901 | 1,271,866 | 63 | 261.31 MB/s |
+| Baseline `BenchmarkFlush` | 1,962,545 | 1,520,620 | 109 | n/a |
+| Reuse `arrs` slice (`BenchmarkFlush`) | 1,835,401 | 1,520,569 | 108 | n/a |
+| Baseline `BenchmarkEndToEndPipeline` | 1,931,032 | 1,271,857 | 63 | 218.38 MB/s |
+| Reuse `arrs` slice (`BenchmarkEndToEndPipeline`) | 1,848,092 | 1,271,872 | 63 | 228.29 MB/s |
+
+Conclusion: **KEEP**.
+
 ### Key Performance Highlights
 
 - **Scanner API**: ~140M lines/second (7ns per line, **zero allocations**)

--- a/pkg/carve/carve.go
+++ b/pkg/carve/carve.go
@@ -122,6 +122,7 @@ type Writer struct {
 	scratch     [][]byte
 	tempColVals [][][]byte
 	tempValids  [][]bool
+	arrScratch  []arrow.Array
 	rows        int
 }
 
@@ -154,6 +155,7 @@ func NewWriter(schema *arrow.Schema, mem memory.Allocator, maxRows int) *Writer 
 		scratch:     make([][]byte, numCols),
 		tempColVals: tempColVals,
 		tempValids:  tempValids,
+		arrScratch:  make([]arrow.Array, numCols),
 	}
 }
 
@@ -220,7 +222,7 @@ func (w *Writer) Flush() (arrow.Record, error) {
 		return nil, nil
 	}
 
-	arrs := make([]arrow.Array, len(w.builders))
+	arrs := w.arrScratch
 	for i, b := range w.builders {
 		arrs[i] = b.NewArray()
 	}
@@ -229,6 +231,9 @@ func (w *Writer) Flush() (arrow.Record, error) {
 
 	for _, a := range arrs {
 		a.Release()
+	}
+	for i := range arrs {
+		arrs[i] = nil
 	}
 
 	w.rows = 0

--- a/pkg/carve/perf_bench_test.go
+++ b/pkg/carve/perf_bench_test.go
@@ -1,0 +1,134 @@
+package carve
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow/memory"
+)
+
+func benchmarkLines() [][]byte {
+	return generateLogLinesAsBytes(8192, 1.0)
+}
+
+func BenchmarkScannerScan(b *testing.B) {
+	scanner, _ := NewExtractor(benchmarkPattern)
+	out := make([][]byte, len(scanner.fields))
+	lines := benchmarkLines()
+	bytesPerIter := int64(0)
+	for _, line := range lines {
+		bytesPerIter += int64(len(line))
+	}
+
+	b.ReportAllocs()
+	b.SetBytes(bytesPerIter)
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		for _, line := range lines {
+			scanner.Scan(line, out)
+		}
+	}
+}
+
+func BenchmarkWriterWriteLinesSIMD(b *testing.B) {
+	ext, _ := NewExtractor(benchmarkPattern)
+	scanner := ext.Scanner(Options{ZeroCopy: true})
+	lines := benchmarkLines()
+	bytesPerIter := int64(0)
+	for _, line := range lines {
+		bytesPerIter += int64(len(line))
+	}
+
+	b.ReportAllocs()
+	b.SetBytes(bytesPerIter)
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		writer := NewWriter(ext.Schema(), memory.DefaultAllocator, len(lines))
+		rec, err := writer.WriteLinesSIMD(lines, scanner)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if rec != nil {
+			rec.Release()
+		}
+	}
+}
+
+func BenchmarkFlush(b *testing.B) {
+	ext, _ := NewExtractor(benchmarkPattern)
+	scanner := ext.Scanner(Options{ZeroCopy: true})
+	lines := benchmarkLines()
+	writer := NewWriter(ext.Schema(), memory.DefaultAllocator, len(lines))
+	for _, line := range lines {
+		scanner.Scan(line, writer.scratch)
+		for i := range writer.scratch {
+			v := writer.scratch[i]
+			writer.builders[i].Append(v)
+		}
+	}
+	writer.rows = len(lines)
+
+	var mStart, mEnd runtime.MemStats
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		runtime.ReadMemStats(&mStart)
+		rec, err := writer.Flush()
+		if err != nil {
+			b.Fatal(err)
+		}
+		if rec != nil {
+			rec.Release()
+		}
+		runtime.ReadMemStats(&mEnd)
+		if i == 0 {
+			b.ReportMetric(float64(mEnd.HeapAlloc-mStart.HeapAlloc), "heap_delta/op")
+		}
+		for _, line := range lines {
+			scanner.Scan(line, writer.scratch)
+			for i := range writer.scratch {
+				v := writer.scratch[i]
+				writer.builders[i].Append(v)
+			}
+		}
+		writer.rows = len(lines)
+	}
+}
+
+func BenchmarkEndToEndPipeline(b *testing.B) {
+	ext, _ := NewExtractor(benchmarkPattern)
+	scanner := ext.Scanner(Options{ZeroCopy: true})
+	lines := benchmarkLines()
+	bytesPerIter := int64(0)
+	for _, line := range lines {
+		bytesPerIter += int64(len(line))
+	}
+
+	var mStart, mEnd runtime.MemStats
+	b.ReportAllocs()
+	b.SetBytes(bytesPerIter)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		runtime.ReadMemStats(&mStart)
+		writer := NewWriter(ext.Schema(), memory.DefaultAllocator, len(lines))
+		rec, err := writer.WriteLinesSIMD(lines, scanner)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if rec == nil {
+			rec, err = writer.Flush()
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+		if rec != nil {
+			rec.Release()
+		}
+		runtime.ReadMemStats(&mEnd)
+		if i == 0 {
+			b.ReportMetric(float64(mEnd.TotalAlloc-mStart.TotalAlloc)/8.192, "B/1k_rows")
+		}
+	}
+}


### PR DESCRIPTION
### Motivation
- Push end-to-end read/write throughput toward hardware limits by adding reproducible, focused benchmarks for the scanner, writer SIMD path, flush, and full pipeline.
- Reduce alloc/GC pressure on the hot Flush path to improve sustained throughput and lower pause/heap churn.
- Document disciplined, reproducible experiments and keep/revert decisions for each micro-optimization attempted.

### Description
- Add a dedicated benchmark file `pkg/carve/perf_bench_test.go` containing `BenchmarkScannerScan`, `BenchmarkWriterWriteLinesSIMD`, `BenchmarkFlush`, and `BenchmarkEndToEndPipeline` with `SetBytes`, allocation reporting, and extra memory metrics (`heap_delta/op`, `B/1k_rows`).
- Reduce per-Flush allocation by reusing a preallocated `[]arrow.Array` scratch buffer (`arrScratch`) on `Writer`, and clear its entries after use instead of allocating a new slice each `Flush`.
- Attempted an inline delimiter scan in `Scanner.Scan` (to replace `bytes.IndexByte`) as an experiment, found it regressed, and reverted that change; the revert and rationale are documented.
- Update `BENCHMARK_REPORT.md` with the reproducible benchmark command, experiment hypotheses, before/after comparison table, and keep/revert conclusions.

### Testing
- Ran targeted benchmark command `go test ./pkg/carve -run '^$' -bench '^(BenchmarkScannerScan|BenchmarkWriterWriteLinesSIMD|BenchmarkFlush|BenchmarkEndToEndPipeline)$' -benchmem -benchtime=3s -count=3`, which completed successfully and produced repeatable results.
- Observed measured impacts (baseline → optimized): `BenchmarkWriterWriteLinesSIMD` ~1,675,974 ns/op → ~1,614,901 ns/op (~3.6% faster), `BenchmarkFlush` ~1,962,545 ns/op → ~1,835,401 ns/op (~6.5% faster, allocs/op 109→108), and `BenchmarkEndToEndPipeline` ~1,931,032 ns/op → ~1,848,092 ns/op (~4.3% faster).
- Performed `go test ./...` and benchmark runs with `-count` to verify stability; all tests and benchmarks completed with `PASS`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8881fc8b8832e8fffe51813264c2c)